### PR TITLE
docs: fix 19 typos in documentation

### DIFF
--- a/ConfigurationProfile.md
+++ b/ConfigurationProfile.md
@@ -211,7 +211,7 @@ Disable the countdown:
 
 (String, optional, default: `continue`)
 
-This key sets the action and label for the button shown when Setup Manger has completed. 
+This key sets the action and label for the button shown when Setup Manager has completed. 
 
 There are four options:
 - `continue`: (default) merely quits Setup Manager and allows the user to continue (probably Setup Assistant or login window)

--- a/Docs/JamfPro-LoginWindow.md
+++ b/Docs/JamfPro-LoginWindow.md
@@ -28,6 +28,6 @@ You will likely need to bind the Mac to a directory service to allow for user lo
 
 ## Auto Advance
 
-The Apple feature to automatically advance through the Setup Assistant screens has a few requirements. The Mac has to be registered in Apple Business Manager or Apple School Manager and assigned to the MDM servier. It also has to be connected with ethernet to a network that can reach the MDM server, all Apple services and other internal services you might configure during enrollment (e.g. directory or IdP server).
+The Apple feature to automatically advance through the Setup Assistant screens has a few requirements. The Mac has to be registered in Apple Business Manager or Apple School Manager and assigned to the MDM server. It also has to be connected with ethernet to a network that can reach the MDM server, all Apple services and other internal services you might configure during enrollment (e.g. directory or IdP server).
 
 Auto Advance doesn't 'kick in' until after Voiceover has introduced itself and if you ever touch any of the controls, AutoAdvance will stop and you have to continue manually.

--- a/Docs/JamfPro-QuickStart.md
+++ b/Docs/JamfPro-QuickStart.md
@@ -58,7 +58,7 @@ You can add more actions here. There are more types of actions available, you ca
 ## Wipe the Test Mac
 
 - on the test mac, choose 'Erase all Contents and Settings' in the Settings app or wipe the Mac using the 'Wipe Computer' remote management command in Jamf Pro
-- click through the initial enrollment dialogs. After you approve the enrollment in your MDM, Setup Manger should appear and perform the actions you configured
+- click through the initial enrollment dialogs. After you approve the enrollment in your MDM, Setup Manager should appear and perform the actions you configured
 - while the installations are progressing, click on "About this Mac…" for information, click again while holding down the option key for even more information
 - hit command-L for a log window. You can also find this log info later at `/Library/Logs/Setup Manager.log`
 

--- a/Docs/JamfPro-UIE.md
+++ b/Docs/JamfPro-UIE.md
@@ -6,11 +6,11 @@ While we strongly recommend to use Automated Device Enrollment where possible, w
 
 Since Prestage enrollment packages are only installed during Automated Device Enrollment, you need to create a policy which installs the Setup Manager pkg and attach that to the `enrollmentComplete` trigger.
 
-Create the Setup Manager profile and make sure it is scoped in a way that it will reach the device immediataly at enrollment. For example, you can create a smart group on the criterium `Enrolled via Automated Device Enrollment` `is` `No` to gather all Macs _not_ enrolled with ADE.
+Create the Setup Manager profile and make sure it is scoped in a way that it will reach the device immediately at enrollment. For example, you can create a smart group on the criterium `Enrolled via Automated Device Enrollment` `is` `No` to gather all Macs _not_ enrolled with ADE.
 
 ## Troubleshooting
 
-With UIE, there _will_ be an unvoidable short delay between the enrollment and when Setup Manager launches. If the pause is very long, you will need to analyse jamf.log and install.log to see where the time is spent. Setup Manager logs will show some events that occur even before Setup Manager is installed and launches, but the time information might be lost or not represented. Use the suggestions here for reducing the time to launch.
+With UIE, there _will_ be an unavoidable short delay between the enrollment and when Setup Manager launches. If the pause is very long, you will need to analyse jamf.log and install.log to see where the time is spent. Setup Manager logs will show some events that occur even before Setup Manager is installed and launches, but the time information might be lost or not represented. Use the suggestions here for reducing the time to launch.
 
 ## Workflow and Profile
 

--- a/Docs/JamfProConnect-SingleTouch.md
+++ b/Docs/JamfProConnect-SingleTouch.md
@@ -4,7 +4,7 @@
 
 In a single touch workflow a tech performs or monitors the initial setup of a device to the point just before the user creates their account. While Setup Manager can run zero-touch workflows, it was built specifically with single-touch workflows in mind.
 
-A single touch workflow can be as easy the tech unpacking the Mac (erasing it with an MDM command or restoring it with Apple Configurator when necessary), connecting it to network, stepping through the initial Setup dialogs, optionally entering the asset tag or other data, monitoring Setup Manager's process until it is finished and then handing over or sending the Mac to the designated end user who continues the setup and creates their account in Setup Assistant.
+A single touch workflow can be as easy as the tech unpacking the Mac (erasing it with an MDM command or restoring it with Apple Configurator when necessary), connecting it to network, stepping through the initial Setup dialogs, optionally entering the asset tag or other data, monitoring Setup Manager's process until it is finished and then handing over or sending the Mac to the designated end user who continues the setup and creates their account in Setup Assistant.
 
 You can use a combination of Jamf Pro, Setup Manager and Jamf Connector, to get a tighter deployment, user assignment and account creation process. This requires a bit more setup and configuration. This workflow allows the tech to monitor the Setup Manager workflow, enter device specific data such as an asset tag and assign _and lock_ the device to a different user, without requiring the end user's login credentials.
 
@@ -14,7 +14,7 @@ You can use a combination of Jamf Pro, Setup Manager and Jamf Connector, to get 
 - Setup Manager
 - Jamf Connect Login configured with SSO
 
-Customized Enrollment with SSO is not _required_ for this workflow. The assignment to the final user is set from the email entered in Setup Manager. Nevertheless, customized enrollment with SSO is useful in this context since restricts Mac enrollment to a group of authorized accounts.
+Customized Enrollment with SSO is not _required_ for this workflow. The assignment to the final user is set from the email entered in Setup Manager. Nevertheless, customized enrollment with SSO is useful in this context since it restricts Mac enrollment to a group of authorized accounts.
 
 You should have Jamf Pro and Jamf Connect configured with the required SSO integrations and thoroughly tested before configuring this workflow. 
 
@@ -24,7 +24,7 @@ Verify that "Collect User and Location information from Directory Service" is **
 
 Add the Setup Manager pkg to the Prestage. Also create a configuration profile for Setup Manager with the workflow to install and configure the software you want to be installed at this stage.
 
-You need to leave least one panel of Setup Assistant _enabled_. Otherwise Setup Manager might not launch.
+You need to leave at least one panel of Setup Assistant _enabled_. Otherwise Setup Manager might not launch.
 
 Setup Manager profile will require a `userEntry` field for `userID` to know which user to assign the Mac to. This will show a field prompting for "User Email." You can of course add other fields to `userEntry` at this time, though they are not required.
 
@@ -46,7 +46,7 @@ Example:
 
 ## Deploy Jamf Connect
 
-You also need to make sure that Jamf Connect (Login) is deployed is installed and configured. There are different approaches to do this.
+You also need to make sure that Jamf Connect (Login) is installed and configured. There are different approaches to do this.
 
 - add Jamf Connect pkg to prestage
 - install Jamf Connect with a pkg policy triggered from Setup Manager workflow

--- a/Docs/JamfSchool-Setup.md
+++ b/Docs/JamfSchool-Setup.md
@@ -16,30 +16,30 @@ Once you have the pkg it needs to be uploaded to Jamf School as an `In House mac
 
 Setup Manager can "watch" for items in a particular file path on the volume. This is a great way to check if an app installed via VPP or In House macOS Apps (custom packages) are installed before moving on to the next action. 
 
-If you intend to "watch" for an item in your Setup Manager workflow ensure to scope the app(s) in the convential way. 
+If you intend to "watch" for an item in your Setup Manager workflow ensure to scope the app(s) in the conventional way. 
 
-Other apps (that are not being monitored through Setup Manager) and profile configurations should be scoped to the target devices in the convential way
+Other apps (that are not being monitored through Setup Manager) and profile configurations should be scoped to the target devices in the conventional way
 
-*How you scope these addtional items will depend on your deployment but as an example this could be done through the App Inventory menu or via a smart / static group.*
+*How you scope these additional items will depend on your deployment but as an example this could be done through the App Inventory menu or via a smart / static group.*
 
 ### Create the Setup Manager Configuration Profile
 
 There are many actions and configurable items available for Setup Manager, which are well [documented here](https://github.com/Jamf-Concepts/Setup-Manager/blob/main/ConfigurationProfile.md). 
 
-*Its worth noting that there are a number of actions that can be performed that are only available for Jamf Pro, these are clearly stated in the documentation.*
+*It's worth noting that there are a number of actions that can be performed that are only available for Jamf Pro, these are clearly stated in the documentation.*
 
 To help you get started on creating a Configuration Profile, there is a [sample profile](https://github.com/Jamf-Concepts/Setup-Manager/blob/main/Examples/sample-jamfschool.mobileconfig). 
 
 This sample profile can then be edited using a text editor tool such as [BBEdit](https://www.barebones.com/products/bbedit/) or a tool specifically for editing plists and profiles, such as [PlistEdit Pro](https://www.fatcatsoftware.com/plisteditpro/). 
 
-If you'd prefer to not edit in text format [iMazing Profile Editor](https://imazing.com/profile-editor) now has a community created payload spefically for Setup Manager which enables you to create a profile in a more user friendly GUI 
+If you'd prefer to not edit in text format [iMazing Profile Editor](https://imazing.com/profile-editor) now has a community created payload specifically for Setup Manager which enables you to create a profile in a more user friendly GUI 
 
 Once you have a configuration profile with the desired actions it should be uploaded to Jamf School. Navigate to
 
 * **Profiles** -> **Overview** -> click **+Create Profile**
 * Click **Upload Custom Profile** -> Find the configuration profile on your system and drag to the window
 * Click **Next**
-* Give the profile and name and description -> click **Next**
+* Give the profile a name and description -> click **Next**
 * Click **Finish**
 * Click **Save** (no need to scope anything at this point)
 
@@ -58,7 +58,7 @@ Finally scope the ADE profile to the required devices
 ### Wipe The Test Mac
 
 * On the test mac, choose `Erase all Contents and Settings` in the Settings app or wipe the Mac using the `Erase Device` remote management command in Jamf Pro
-* Click through the initial enrollment dialogs. After you approve the enrollment in your MDM, Setup Manger should appear and perform the actions you configured
+* Click through the initial enrollment dialogs. After you approve the enrollment in your MDM, Setup Manager should appear and perform the actions you configured
 * While the installations are progressing, click on "About this Mac…" for information, click again while holding down the option key for even more information
 * Hit `command-L` for a log window. You can also find this log info later at `/Library/Logs/Setup Manager.log`
 

--- a/Docs/Network.md
+++ b/Docs/Network.md
@@ -78,7 +78,7 @@ Example: empty `networkCheck` array to force Network icon to always show
 
 ## Network Change logging
 
-Setup Manager 1.3 adds logging for changes to network interfaces. It is possible that there will multiple entries in the log with regards to the same network change. Most changes logged will be neutral and should not affect your deployment negatively.
+Setup Manager 1.3 adds logging for changes to network interfaces. It is possible that there will be multiple entries in the log with regards to the same network change. Most changes logged will be neutral and should not affect your deployment negatively.
 
 However, it is possible that changes to the network configuration of a device can influence the deployment workflow. Changes to network or Wi-Fi configurations and other network or security tools might disrupt the network connectivity during enrollment. This might interrupt or cancel downloads.
 

--- a/Docs/Webhooks.md
+++ b/Docs/Webhooks.md
@@ -4,11 +4,11 @@
 
 (Dict, optional)
 
-Setup Manager can send webhooks to inform other services of its status. The configuration for the webhooks in all stored under the top-level `webhooks` key.
+Setup Manager can send webhooks to inform other services of its status. The configuration for the webhooks is all stored under the top-level `webhooks` key.
 
 The webhooks dict can contain two keys, both of which are again dicts. `started` defines the webhook or webhooks that are called when Setup Manager starts its workflow, and the other `finished` defines the webhook or webhooks when it finishes the workflow.
 
-When the either the `started` or `finished` key is missing, no webhook will be sent for that event.
+When either the `started` or `finished` key is missing, no webhook will be sent for that event.
 
 Example:
 


### PR DESCRIPTION
## Summary

Fixes 19 typos across the documentation. Markdown prose only - no configuration keys, no code, no behaviour changes.

**Docs/JamfProConnect-SingleTouch.md**
- `can be as easy the tech unpacking the Mac` -> `can be as easy as the tech unpacking the Mac`
- `You need to leave least one panel` -> `You need to leave at least one panel`
- `Jamf Connect (Login) is deployed is installed and configured` -> `Jamf Connect (Login) is installed and configured`
- `since restricts Mac enrollment` -> `since it restricts Mac enrollment`

**Docs/Webhooks.md**
- `The configuration for the webhooks in all stored under` -> `...is all stored under`
- `When the either the \`started\` or \`finished\` key is missing` -> `When either the \`started\` or \`finished\` key is missing`

**Docs/JamfSchool-Setup.md**
- `in the convential way` -> `in the conventional way` (2 occurrences)
- `these addtional items` -> `these additional items`
- `*Its worth noting` -> `*It's worth noting`
- `payload spefically for Setup Manager` -> `payload specifically for Setup Manager`
- `Give the profile and name and description` -> `Give the profile a name and description`

**Docs/JamfPro-LoginWindow.md**
- `assigned to the MDM servier` -> `assigned to the MDM server`

**Docs/JamfPro-UIE.md**
- `reach the device immediataly at enrollment` -> `reach the device immediately at enrollment`
- `an unvoidable short delay` -> `an unavoidable short delay`

**Docs/Network.md**
- `there will multiple entries in the log` -> `there will be multiple entries in the log`

**Product name: `Setup Manger` -> `Setup Manager`** (all 3 occurrences in the repo)
- `Docs/JamfSchool-Setup.md`, `Docs/JamfPro-QuickStart.md`, `ConfigurationProfile.md`

CRLF line endings in `Docs/JamfSchool-Setup.md` are preserved byte-for-byte; the diff is 19 insertions / 19 deletions with no whitespace churn.